### PR TITLE
Add support for Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+
 android {
     compileSdkVersion 26
     buildToolsVersion '26.0.2'
@@ -92,6 +94,8 @@ dependencies {
     compile "io.reactivex.rxjava2:rxandroid:2.0.1"
 
     compile "com.google.android.gms:play-services-maps:$gmsFirebaseVersion" // should be the same version as rxlocation pulls
+
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,17 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.kotlin_version = '1.1.61'
+
     repositories {
         google()
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.google.gms:google-services:3.0.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Doesn't have any specialized configuration, so `.kt` files are expected to be placed along side `.java` files (i.e. under the standard `src/main/java` source set).

See also: #24 