### PR TITLE
Limit CircleCI build memory usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ jobs:
     working_directory: ~/android-ponewheel
     docker:
       - image: circleci/android:api-27-alpha
+    environment:
+      - _JAVA_OPTIONS: "-Xmx1024m"
+      - JVM_OPTS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
     steps:
       - checkout
       - run:
@@ -28,7 +31,7 @@ jobs:
           key: gradle-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
       - run:
           name: Android build
-          command: ./gradlew --no-daemon --stacktrace assemble check
+          command: ./gradlew --no-daemon --stacktrace --max-workers 2 assemble check
       - store_artifacts:
           path: app/build/reports
           destination: reports


### PR DESCRIPTION
Based on CircleCi forum [discussion], adjusting memory limits in hopes of fixing out-of-memory errors.

[discussion]: https://discuss.circleci.com/t/circle-ci-v2-and-android-memory-issues/11207