### PR TITLE
Disable pre dex and reduce parallelism for CI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - image: circleci/android:api-27-alpha
     environment:
       - _JAVA_OPTIONS: "-Xmx1024m"
-      - JVM_OPTS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
+      - JVM_OPTS: -Xmx1024m -XX:ParallelGCThreads=1 -XX:ConcGCThreads=1 -XX:ParallelGCThreads=1 -Djava.util.concurrent.ForkJoinPool.common.parallelism=1
     steps:
       - checkout
       - run:
@@ -24,14 +24,14 @@ jobs:
           key: gradle-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
       - run:
           name: Download Dependencies
-          command: ./gradlew --no-daemon --stacktrace androidDependencies
+          command: ./gradlew --no-daemon --stacktrace -PdisablePreDex androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
           key: gradle-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
       - run:
           name: Android build
-          command: ./gradlew --no-daemon --stacktrace --max-workers 2 assemble check
+          command: ./gradlew --no-daemon --stacktrace --max-workers 1 -PdisablePreDex assemble check
       - store_artifacts:
           path: app/build/reports
           destination: reports


### PR DESCRIPTION
Attempting to further reduce memory usage during CircleCI builds to address [lingering issues](https://github.com/ponewheel/android-ponewheel/issues/28#issuecomment-351344075).

Disables pre dex which is [unnecessary for CI builds]:

> By default the Gradle android plugin pre-dexes dependencies, converting their Java bytecode into Android bytecode. This speeds up development greatly since gradle only needs to do incremental dexing as you change code.
>
> Because CircleCI always runs clean builds this pre-dexing has no benefit; in fact it makes compilation slower and can also use large quantities of memory. We recommend disabling pre-dexing for Android builds on CircleCI.

See also: [Building multi-dex Android project gets OOM](https://discuss.circleci.com/t/building-multi-dex-android-project-gets-oom/315)

[unnecessary for CI builds]: https://circleci.com/docs/1.0/android/#disable-pre-dexing-to-improve-build-performance