### PR TITLE
Creates persistent notification which shows battery level

### DIFF
--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -234,6 +234,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
         mContext = this;
 
+        startStatusNotification();
 
         EventBus.getDefault().register(this);
         // TODO unbind in onPause or whatever is recommended by goog
@@ -276,6 +277,26 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                         new DebugDrawerMockBle(this),
                         new SettingsModule(this)
                 ).build();
+    }
+
+    private void startStatusNotification() {
+        NotificationCompat.Builder mBuilder =
+                new NotificationCompat.Builder(mContext, "ponewheel")
+                        .setSmallIcon(R.mipmap.ic_launcher)
+                        .setContentTitle("pOW status")
+                        .setColor(0x008000)
+                        .setContentText("battery: 46%")
+                        .setOngoing(true)
+                        .setAutoCancel(true);
+        android.app.NotificationManager mNotifyMgr = (android.app.NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        assert mNotifyMgr != null;
+        mNotifyMgr.notify("statusNotificationTag",0, mBuilder.build());
+    }
+
+    private void stopStatusNotification() {
+        android.app.NotificationManager mNotifyMgr = (android.app.NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        assert mNotifyMgr != null;
+        mNotifyMgr.cancel("statusNotificationTag", 0);
     }
 
     public BluetoothUtil getBluetoothUtil() {
@@ -421,6 +442,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
             unbindService(mVibrateConnection);
         }
         App.INSTANCE.getSharedPreferences().removeListener(this);
+        stopStatusNotification();
         super.onDestroy();
     }
 

--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -123,6 +123,9 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     net.kwatts.powtools.databinding.ActivityMainBinding mBinding;
     BluetoothUtil bluetoothUtil;
 
+    private NotificationCompat.Builder mStatusNotificationBuilder;
+    private static final String POW_NOTIF_CHANNEL_STATUS = "pow_status";
+    private static final String POW_NOTIF_TAG_STATUS = "statusNotificationTag";
 
     PieChart mBatteryChart;
     Ride ride;
@@ -179,6 +182,11 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
 
     public void updateBatteryRemaining(final int percent) {
+        // Update ongoing notification
+        mStatusNotificationBuilder.setContentText("battery: " + percent + "%");
+        android.app.NotificationManager mNotifyMgr = (android.app.NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+        mNotifyMgr.notify(POW_NOTIF_TAG_STATUS, 0, mStatusNotificationBuilder.build());
+
         runOnUiThread(() -> {
             try {
                 ArrayList<PieEntry> entries = new ArrayList<>();
@@ -303,23 +311,23 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
     }
 
     private void startStatusNotification() {
-        NotificationCompat.Builder mBuilder =
-                new NotificationCompat.Builder(mContext, "ponewheel")
+        mStatusNotificationBuilder =
+                new NotificationCompat.Builder(mContext, POW_NOTIF_CHANNEL_STATUS)
                         .setSmallIcon(R.mipmap.ic_launcher)
-                        .setContentTitle("pOW status")
+                        .setContentTitle("Onewheel Status")
                         .setColor(0x008000)
-                        .setContentText("battery: 46%")
+                        .setContentText("Waiting for connection...")
                         .setOngoing(true)
                         .setAutoCancel(true);
         android.app.NotificationManager mNotifyMgr = (android.app.NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         assert mNotifyMgr != null;
-        mNotifyMgr.notify("statusNotificationTag",0, mBuilder.build());
+        mNotifyMgr.notify(POW_NOTIF_TAG_STATUS,0, mStatusNotificationBuilder.build());
     }
 
     private void stopStatusNotification() {
         android.app.NotificationManager mNotifyMgr = (android.app.NotificationManager) getSystemService(NOTIFICATION_SERVICE);
         assert mNotifyMgr != null;
-        mNotifyMgr.cancel("statusNotificationTag", 0);
+        mNotifyMgr.cancel(POW_NOTIF_TAG_STATUS, 0);
     }
 
     public BluetoothUtil getBluetoothUtil() {


### PR DESCRIPTION
I apologize for taking so long to get to this.

This change is super simple and I think quite a bit of further work could go into this.

As it stands now a notification pops up when the app opens and every time the battery indicator in the app updates, the notification is updated with the current charge of the battery.

I've been reading a little bit about notifications and they could do so much more.

Some things that I think could follow this change:
- Make taping the notification open the app again.
- Change the notification icon to a better one.
- Make the notification display more info if the user expands it.