### PR TITLE
Check if device supports Bluetooth

### DIFF
--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -600,8 +600,10 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
 
         if (getBluetoothUtil().isConnected()) {
             mOWDevice.bluetoothStatus.set("Connected");
-        } else {
+        } else if(getBluetoothUtil().isBtAdapterAvailable(this)) {
             getBluetoothUtil().reconnect(this);
+        } else  {
+            Toast.makeText(this, getString(R.string.bt_is_not_supported), Toast.LENGTH_SHORT).show();
         }
 
         alertsController.recaptureMedia(this);

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtil.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtil.java
@@ -1,6 +1,7 @@
 package net.kwatts.powtools.util;
 
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.content.Context;
 import net.kwatts.powtools.MainActivity;
 import net.kwatts.powtools.model.OWDevice;
 
@@ -14,4 +15,5 @@ public interface BluetoothUtil {
     void startScanning();
     BluetoothGattCharacteristic getCharacteristic(String onewheelCharacteristicLightingMode);
     void writeCharacteristic(BluetoothGattCharacteristic lc);
+    boolean isBtAdapterAvailable(Context context);
 }

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
@@ -397,7 +397,7 @@ public class BluetoothUtilImpl implements BluetoothUtil{
 
     @Override
     public void reconnect(MainActivity activity) {
-        if (isBtAvailable(activity)) {
+        if (isBtAdapterAvailable(activity)) {
             Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
             activity.startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
         } else {
@@ -405,7 +405,8 @@ public class BluetoothUtilImpl implements BluetoothUtil{
         }
     }
 
-    private boolean isBtAvailable(Context context) {
+    @Override
+    public boolean isBtAdapterAvailable(Context context) {
         return context.getPackageManager()
                 .hasSystemFeature(PackageManager.FEATURE_BLUETOOTH);
     }

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
@@ -16,8 +16,10 @@ import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.ParcelUuid;
 
+import android.util.Log;
 import net.kwatts.powtools.App;
 import net.kwatts.powtools.BuildConfig;
 import net.kwatts.powtools.MainActivity;
@@ -395,8 +397,17 @@ public class BluetoothUtilImpl implements BluetoothUtil{
 
     @Override
     public void reconnect(MainActivity activity) {
-        Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
-        activity.startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
+        if (isBtAvailable(activity)) {
+            Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+            activity.startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
+        } else {
+            Log.e(TAG, "Bluetooth is not available");
+        }
+    }
+
+    private boolean isBtAvailable(Context context) {
+        return context.getPackageManager()
+                .hasSystemFeature(PackageManager.FEATURE_BLUETOOTH);
     }
 
     @Override

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilMockImpl.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilMockImpl.java
@@ -3,6 +3,7 @@ package net.kwatts.powtools.util;
 import android.annotation.SuppressLint;
 import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
+import android.content.Context;
 import android.os.Handler;
 
 import net.kwatts.powtools.App;
@@ -72,6 +73,11 @@ public class BluetoothUtilMockImpl implements BluetoothUtil{
     public boolean isScanning() {
         Timber.d("isScanning " + isScanning);
         return isScanning;
+    }
+
+    @Override
+    public boolean isBtAdapterAvailable(Context context) {
+        return true;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="pads">Rider Pads</string>
     <string name="temp">Temperature</string>
     <string name="power">Power</string>
+    <string name="bt_is_not_supported">Bluetooth is not available</string>
 
     <string-array name="ow_ridemode_array">
         <item>CLASSIC</item>


### PR DESCRIPTION
Even if AndroidManifest contains `uses-feature` requirement for Bluetooth it is still possible to manually install apk to device without Bluetooth. In my case I install app to Android emulator which doesn't have Bt.

Code without this fix causes infinitive loop:
1. `MainActivity.onResume` calls `reconnect()` if Bl is not connected
2. `BluetoothUtilImpl.reconnect()` try to start Bl enabling intent.
3. Intent fails and `MainActivity.onResume` is called. Loop begins again