### PR TITLE
Increase minSdk to 21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         applicationId "net.kwatts.powtools"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 21
         versionCode 31
         versionName "3.3"


### PR DESCRIPTION
With current app implementation we do not support SDK 19. [Detailed explanation](https://github.com/ponewheel/android-ponewheel/issues/67#issuecomment-402958174)

closes #67