### PR TITLE
Invalidate Toolbar menu on UI thread

### DIFF
--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -48,6 +48,7 @@ import io.palaima.debugdrawer.DebugDrawer;
 import io.palaima.debugdrawer.commons.SettingsModule;
 import io.palaima.debugdrawer.timber.TimberModule;
 import io.reactivex.Single;
+import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableObserver;
 import io.reactivex.observers.DisposableSingleObserver;
@@ -921,6 +922,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 connectionStatusDisposable.dispose();
             }
             connectionStatusDisposable = bluetoothConnectionService.getBluetoothUtil().getConnectionStatus()
+                    .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
                             (ConnectionStatus connectionStatus) -> {
                                 invalidateOptionsMenu();
@@ -932,6 +934,7 @@ public class MainActivity extends AppCompatActivity implements SharedPreferences
                 batteryPercentageDisposable.dispose();
             }
             batteryPercentageDisposable = bluetoothConnectionService.getBluetoothUtil().getBatteryPercentage()
+                    .observeOn(AndroidSchedulers.mainThread())
                     .subscribe(
                             this::updateBatteryRemaining,
                             Timber::e


### PR DESCRIPTION
**Issue**: on first app start toolbar is hidden under StatusBar. 
**Reason**: events from observable was consumed on different thread. So initial `invalidateMenuOption()` call was consumed even before layout is measured.
**Solution**: handle events explicitly on UI thread.

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/1947112/42732069-b00e4af8-8822-11e8-87df-dbe0192f0dbf.png" width="150"> | <img src="https://user-images.githubusercontent.com/1947112/42732071-b5446b2e-8822-11e8-8bb7-ce0c2bc49a05.png" width="150"> |