### PR TITLE
Meter cleanup try2

### DIFF
--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -210,6 +210,7 @@ public class MainActivity extends AppCompatActivity implements
                 mColors.add(ColorTemplate.rgb("#2E7D32")); //green
                 mColors.add(ColorTemplate.rgb("#C62828")); //red
                 dataSet.setColors(mColors);
+                dataSet.setDrawValues(false);
 
                 PieData newPieData = new PieData( dataSet);
                 mBatteryChart.setCenterText(percent + "%");


### PR DESCRIPTION
Remove labels from the percent remaining donut graph.  The center remaining% is still there, just not the little labels.  I think it looks cleaner without the redundant information.