### PR TITLE
Battery v4

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
             android:required="false" />
         <activity
             android:name=".MainActivity"
+            android:launchMode="singleTask"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -1,9 +1,6 @@
 package net.kwatts.powtools;
 
 import android.Manifest;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -18,8 +15,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.app.AppCompatDelegate;

--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -140,7 +140,7 @@ public class MainActivity extends AppCompatActivity implements
         final String title = event.title;
         final String message = event.message;
         runOnUiThread(() -> {
-            notify.event(title, message);
+            notify.status(title, message);
         });
     }
 
@@ -167,19 +167,20 @@ public class MainActivity extends AppCompatActivity implements
 
     public void updateBatteryRemaining(final int percent) {
         // Update ongoing notification
-        notify.status(percent);
+        notify.remain(percent);
         notify.alert(percent);
 
         runOnUiThread(() -> {
             try {
                 ArrayList<PieEntry> entries = new ArrayList<>();
-                entries.add(new PieEntry((int)percent, (int)0));
-                entries.add(new PieEntry((int)100 - percent, (int)1));
+                entries.add(new PieEntry(percent, 0));
+                entries.add(new PieEntry(100 - percent, 1));
                 PieDataSet dataSet = new PieDataSet(entries, "battery percentage");
                 ArrayList<Integer> mColors = new ArrayList<>();
                 mColors.add(ColorTemplate.rgb("#2E7D32")); //green
                 mColors.add(ColorTemplate.rgb("#C62828")); //red
                 dataSet.setColors(mColors);
+                dataSet.setDrawValues(false);
 
                 PieData newPieData = new PieData( dataSet);
                 mBatteryChart.setCenterText(percent + "%");

--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -470,11 +470,13 @@ public class MainActivity extends AppCompatActivity implements
                 break;
             case R.id.menu_stop:
                 getBluetoothUtil().stopScanning();
+                notify.waiting();
                 this.invalidateOptionsMenu();
                 break;
             case R.id.menu_disconnect:
                 mOWDevice.isConnected.set(false);
                 getBluetoothUtil().disconnect();
+                notify.waiting();
                 Timber.i("Disconnected from device by user.");
                 deviceConnectedTimer(false);
                 mLoggingHandler.removeCallbacksAndMessages(null);

--- a/app/src/main/java/net/kwatts/powtools/MainActivity.java
+++ b/app/src/main/java/net/kwatts/powtools/MainActivity.java
@@ -16,6 +16,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
@@ -254,15 +255,6 @@ public class MainActivity extends AppCompatActivity implements
     public void deviceConnectedTimer(final boolean start) {
         runOnUiThread(() -> {
             if (start) {
-                final Handler handler = new Handler();
-                handler.postDelayed(new Runnable() {
-                    public void run() {
-                        if (App.INSTANCE.getSharedPreferences().getStatusMode() == 2) {
-                            mOWDevice.sendKeyChallengeForGemini(getBluetoothUtil());
-                            handler.postDelayed(this, 15000);
-                        }
-                    }
-                }, 15000);
 /*
                 mChronometer.setOnChronometerTickListener(new Chronometer.OnChronometerTickListener() {
                     @Override
@@ -342,6 +334,16 @@ public class MainActivity extends AppCompatActivity implements
                         new SettingsModule(this),
                         new TimberModule()
                 ).build();
+
+        final Handler handler = new Handler(Looper.getMainLooper());
+        handler.postDelayed(new Runnable() {
+            public void run() {
+                if (App.INSTANCE.getSharedPreferences().getStatusMode() == 2) {
+                    mOWDevice.sendKeyChallengeForGemini(getBluetoothUtil());
+                }
+                handler.postDelayed(this, 15000);
+            }
+        }, 15000);
     }
 
     private void createNotificationChannel() {
@@ -573,6 +575,7 @@ public class MainActivity extends AppCompatActivity implements
                 break;
             case R.id.menu_disconnect:
                 mOWDevice.isConnected.set(false);
+                App.INSTANCE.getSharedPreferences().setStatusMode(0);
                 getBluetoothUtil().disconnect();
                 Timber.i("Disconnected from device by user.");
                 deviceConnectedTimer(false);

--- a/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
+++ b/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
@@ -121,7 +121,6 @@ public class OWDevice extends BaseObservable implements DeviceInterface {
     private double[] batteryVoltageCells = new double[16];
 
     private static boolean updateBatteryChanges = true;
-    private static String updateBatteryMethod = "";
 
 
     public static final String OnewheelServiceUUID = "e659f300-ea98-11e3-ac10-0800200c9a66";
@@ -288,8 +287,8 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
         deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicLifetimeOdometer, KEY_LIFETIME_ODOMETER,   "",0,false));                             // 2
         deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicLightingMode,     KEY_LIGHTING_MODE,       "LIGHTS",0,false));                       // 3
         deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicBatteryRemaining, KEY_BATTERY_INITIAL,     "BATTERY AT START (%)",0,false));         // 4
-        deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicLastErrorCode,    KEY_LAST_ERROR_CODE,     "LAST ERROR CODE",0,false));              // 5
-        deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicBatteryTemp,      KEY_BATTERY_TEMP,        "BATTERY TEMP",0,false));                 // 6
+        deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicLastErrorCode,    KEY_LAST_ERROR_CODE,     "LAST ERROR CODE",1,false));              // 5
+        deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicBatteryTemp,      KEY_BATTERY_TEMP,        "BATTERY TEMP",1,false));                 // 6
         deviceReadCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicRidingMode,       KEY_RIDE_MODE,           "RIDING MODE",0,false));                  // 7
 
         deviceNotifyCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicUartSerialRead,   KEY_SERIAL_READ,         "",0,false));// 18
@@ -395,6 +394,10 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
         byte[] incomingValue = incomingCharacteristic.getValue();
 
         DeviceCharacteristic dc = characteristics.get(incomingUuid);
+
+        if (dc == null) {
+            return;
+        }
 
         String dev_uuid = dc.uuid.get();
 
@@ -749,8 +752,10 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
                 remaining = Battery.getRemainingDefault();
             }
 
-            dc.value.set(Integer.toString(remaining));
-            mainActivity.updateBatteryRemaining(remaining);
+            if (Integer.toString(remaining) != dc.value.get()) {
+                dc.value.set(Integer.toString(remaining));
+                mainActivity.updateBatteryRemaining(remaining);
+            }
 
             updateBatteryChanges = false;
         }

--- a/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
+++ b/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
@@ -310,7 +310,6 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
         deviceNotifyCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicTiltAngleRoll,    KEY_TILT_ANGLE_ROLL,     "TILT ANGLE ROLL",0,true));           // 15
         deviceNotifyCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicTemperature,      KEY_CONTROLLER_TEMP,     "",0,true));                          // 16
         deviceNotifyCharacteristics.add(new DeviceCharacteristic(MockOnewheelCharacteristicMotorTemp,    KEY_MOTOR_TEMP,          "", 0,false));// 17
-        deviceNotifyCharacteristics.add(new DeviceCharacteristic(OnewheelCharacteristicBatteryTemp,      KEY_BATTERY_TEMP,        "BATTERY TEMP",0,true));                 // 18
 
 /*
         deviceNotifyCharacteristics.add(new DeviceCharacteristic()
@@ -497,7 +496,10 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
 
         //EventBus.getDefault().post(new DeviceBatteryRemainingEvent(batteryLevel));
         //dc.value.set(Integer.toString(batteryLevel));
-        updateBatteryChanges |= Battery.setRemaining(batteryLevel);
+        if (Battery.setRemaining(batteryLevel)) {
+            updateBatteryChanges = true;
+            Battery.saveStateTwoX(App.INSTANCE.getSharedPreferences());
+        }
     }
 
     public void processPitch(byte[] incomingValue, DeviceCharacteristic dc) {
@@ -747,7 +749,6 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
                 remaining = Battery.getRemainingCells();
             } else if (prefs.isRemainTwoX()) {
                 remaining = Battery.getRemainingTwoX();
-                Battery.saveStateTwoX(prefs);
             } else {
                 remaining = Battery.getRemainingDefault();
             }

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtil.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtil.java
@@ -16,4 +16,5 @@ public interface BluetoothUtil {
     void startScanning();
     BluetoothGattCharacteristic getCharacteristic(String onewheelCharacteristicLightingMode);
     void writeCharacteristic(BluetoothGattCharacteristic lc);
+    int getStatusMode();
 }

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
@@ -68,6 +68,7 @@ public class BluetoothUtilImpl implements BluetoothUtil{
     private long mDisconnected_time;
     private int mRetryCount = 0;
 
+    private Handler handler;
 
     public static boolean isGemini = false;
 
@@ -84,6 +85,19 @@ public class BluetoothUtilImpl implements BluetoothUtil{
         //assert manager != null;
         //mBluetoothAdapter = manager.getAdapter();
         mOWDevice.bluetoothLe.set("On");
+
+        handler = new Handler(Looper.getMainLooper());
+
+        final int repeatTime = 120000; //every 2 minutes
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (App.INSTANCE.getSharedPreferences().getStatusMode() == 2) {
+                    walkReadQueue(1);
+                }
+                handler.postDelayed(this, repeatTime);
+            }
+        }, repeatTime);
     }
 
     private final BluetoothGattCallback mGattCallback = new BluetoothGattCallback() {
@@ -143,7 +157,8 @@ public class BluetoothUtilImpl implements BluetoothUtil{
             // Stability updates per https://github.com/ponewheel/android-ponewheel/issues/86#issuecomment-460033659
             // Step 1: In OnServicesDiscovered, JUST read the firmware version.
             Timber.d("Stability Step 1: Only reading the firmware version!");
-            new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+            //new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+            handler.postDelayed(new Runnable() {
                 public void run() {
                     BluetoothUtilImpl.this.mGatt.readCharacteristic(BluetoothUtilImpl.this.owGatService.getCharacteristic(UUID.fromString(OWDevice.OnewheelCharacteristicFirmwareRevision)));
                 }
@@ -493,6 +508,9 @@ public class BluetoothUtilImpl implements BluetoothUtil{
     private void onOWStateChangedToDisconnected(BluetoothGatt gatt, Context context) {
         //TODO: we really should have a BluetoothService we kill and restart
         Timber.i("We got disconnected from our Device: " + gatt.getDevice().getAddress());
+	   if (Looper.myLooper() == null) {
+	       Looper.prepare();
+        }
         Toast.makeText(mainActivity, "We got disconnected from our device: " + gatt.getDevice().getAddress(), Toast.LENGTH_SHORT).show();
 
         mainActivity.deviceConnectedTimer(false);
@@ -703,16 +721,13 @@ public class BluetoothUtilImpl implements BluetoothUtil{
         mGatt.writeCharacteristic(bluetoothGattCharacteristic);
     }
 
-
-    public void whenActuallyConnected() {
-
-
-        for(OWDevice.DeviceCharacteristic deviceCharacteristic: mOWDevice.getNotifyCharacteristics()) {
-            String uuid = deviceCharacteristic.uuid.get();
-            if (uuid != null && deviceCharacteristic.isNotifyCharacteristic) {
+    private void walkNotifyQueue(int state) {
+        for(OWDevice.DeviceCharacteristic dc: mOWDevice.getNotifyCharacteristics()) {
+            String uuid = dc.uuid.get();
+            if (uuid != null && dc.isNotifyCharacteristic && dc.state == state) {
                 BluetoothGattCharacteristic localCharacteristic = owGatService.getCharacteristic(UUID.fromString(uuid));
                 if (localCharacteristic != null) {
-                    if (isCharacteristicNotifiable(localCharacteristic) && deviceCharacteristic.isNotifyCharacteristic) {
+                    if (isCharacteristicNotifiable(localCharacteristic) && dc.isNotifyCharacteristic) {
                         mGatt.setCharacteristicNotification(localCharacteristic, true);
                         BluetoothGattDescriptor descriptor = localCharacteristic.getDescriptor(UUID.fromString(OWDevice.OnewheelConfigUUID));
                         Timber.d( "descriptorWriteQueue.size:" + descriptorWriteQueue.size());
@@ -727,14 +742,15 @@ public class BluetoothUtilImpl implements BluetoothUtil{
                             Timber.d( uuid + " has been set for notifications");
                         }
                     }
-
                 }
-
             }
         }
+    }
 
+    private void walkReadQueue(int state) {
         for(OWDevice.DeviceCharacteristic dc : mOWDevice.getReadCharacteristics()) {
-            if (dc.uuid.get() != null) {
+            if (dc.uuid.get() != null && !dc.isNotifyCharacteristic && dc.state == state) {
+                Timber.d("uuid:%s, state:%d", dc.uuid.get(), dc.state);
                 BluetoothGattCharacteristic c = owGatService.getCharacteristic(UUID.fromString(dc.uuid.get()));
                 if (c != null) {
                     if (isCharacteristicReadable(c)) {
@@ -750,6 +766,12 @@ public class BluetoothUtilImpl implements BluetoothUtil{
                 }
             }
         }
+    }
+
+    public void whenActuallyConnected() {
+        walkNotifyQueue(0);
+        walkReadQueue(0);
+        walkReadQueue(1);
 
         App.INSTANCE.getSharedPreferences().setStatusMode(2);
 

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilImpl.java
@@ -70,6 +70,7 @@ public class BluetoothUtilImpl implements BluetoothUtil{
     private int statusMode = 0;
 
     private Handler handler;
+    private static int periodicSchedulerCount = 0;
 
     public static boolean isGemini = false;
 
@@ -88,17 +89,7 @@ public class BluetoothUtilImpl implements BluetoothUtil{
         mOWDevice.bluetoothLe.set("On");
 
         handler = new Handler(Looper.getMainLooper());
-
-        final int repeatTime = 60000; //every minute
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (statusMode == 2) {
-                    walkReadQueue(1);
-                }
-                handler.postDelayed(this, repeatTime);
-            }
-        }, repeatTime);
+        periodicCharacteristics();
     }
 
     private final BluetoothGattCallback mGattCallback = new BluetoothGattCallback() {
@@ -726,6 +717,30 @@ public class BluetoothUtilImpl implements BluetoothUtil{
     @Override
     public int getStatusMode() {
         return statusMode;
+    }
+
+    private void periodicCharacteristics() {
+        final int repeatTime = 60000; //every minute
+
+        periodicSchedulerCount++;
+
+        if (statusMode == 2) {
+            walkReadQueue(1);
+        }
+
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (statusMode == 2) {
+                    walkReadQueue(1);
+                }
+                if (periodicSchedulerCount == 1) {
+                    handler.postDelayed(this, repeatTime);
+                } else {
+                    periodicSchedulerCount--;
+                }
+            }
+        }, repeatTime);
     }
 
     private void walkNotifyQueue(int state) {

--- a/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilMockImpl.java
+++ b/app/src/main/java/net/kwatts/powtools/util/BluetoothUtilMockImpl.java
@@ -30,6 +30,7 @@ public class BluetoothUtilMockImpl implements BluetoothUtil{
     Handler mockLoopHandler = new Handler();
     private boolean isScanning = false;
     private boolean isGemini = false;
+    private int statusMode = 0;
 
 
 
@@ -169,6 +170,11 @@ public class BluetoothUtilMockImpl implements BluetoothUtil{
     @Override
     public void writeCharacteristic(BluetoothGattCharacteristic lc) {
         Timber.d("writeChar" + lc);
+    }
+
+    @Override
+    public int getStatusMode() {
+        return statusMode;
     }
 
     private void updateLog(String s) {

--- a/app/src/main/java/net/kwatts/powtools/util/Notify.java
+++ b/app/src/main/java/net/kwatts/powtools/util/Notify.java
@@ -125,21 +125,27 @@ public class Notify {
     }
 
     private void startStatusNotification() {
+        Intent intent = new Intent(mContext, MainActivity.class);
+        PendingIntent contentIntent = PendingIntent.getActivity(
+                mContext, 0, intent, 0);
+
         notifyStatus = new NotificationCompat.Builder(mContext, OW_STATUS_ID+"")
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("Onewheel Status")
                         .setColor(Color.parseColor("#fcb103"))
                         .setContentText("Waiting for connection...")
+                        .setContentIntent(contentIntent)
                         .setOngoing(true)
-                        .setAutoCancel(true);
+                        .setAutoCancel(false);
 
         notifyRemain = new NotificationCompat.Builder(mContext, REMAINING_ID+"")
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("Battery:")
                         .setColor(Color.parseColor("#fcb103"))
                         .setContentText("-%")
+                        .setContentIntent(contentIntent)
                         .setOngoing(true)
-                        .setAutoCancel(true);
+                        .setAutoCancel(false);
         notifyRemain.setProgress(100, 0, false);
 
         notifyAlert75 = new NotificationCompat.Builder(mContext, ALERT_75_ID+"")

--- a/app/src/main/java/net/kwatts/powtools/util/Notify.java
+++ b/app/src/main/java/net/kwatts/powtools/util/Notify.java
@@ -1,0 +1,231 @@
+package net.kwatts.powtools.util;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Typeface;
+import android.graphics.Color;
+import android.location.Address;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
+import android.support.v4.app.ActivityCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.app.AppCompatDelegate;
+import android.support.v4.content.ContextCompat;
+
+import net.kwatts.powtools.MainActivity;
+import net.kwatts.powtools.R;
+
+import timber.log.Timber;
+
+public class Notify {
+    private static final String TAG_STATUS   = "powStatusNotificationTag";
+    private static final int    REMAINING_ID = 101;
+    private static final String REMAINING_CN = "Battery Status";
+    private static final String REMAINING_CD = "Show battery status for Onewheel";
+
+    private static final String TAG_ALERT    = "powAlertNotificationTag";
+    private static final String ALERT_GR_KEY = "pow_alert_group";
+    private static final int    ALERT_75_ID  = 201;
+    private static final String ALERT_75_CN  = "Battery 75% Remaining";
+    private static final String ALERT_75_CD  = "Alarm when battery is 75%";
+
+    private static final int    ALERT_50_ID  = 202;
+    private static final String ALERT_50_CN  = "Battery 50% Remaining";
+    private static final String ALERT_50_CD  = "Alarm when battery is 50%";
+
+    private static final int    ALERT_25_ID  = 203;
+    private static final String ALERT_25_CN  = "Battery 25% Remaining";
+    private static final String ALERT_25_CD  = "Alarm when battery is 25%";
+
+    private static final int    ALERT_05_ID  = 204;
+    private static final String ALERT_05_CN  = "Battery 5% Remaining";
+    private static final String ALERT_05_CD  = "Alarm when battery is 5%";
+
+    private NotificationCompat.Builder notifyStatus;
+    private NotificationCompat.Builder notifyAlert75;
+    private NotificationCompat.Builder notifyAlert50;
+    private NotificationCompat.Builder notifyAlert25;
+    private NotificationCompat.Builder notifyAlert05;
+
+    private NotificationManagerCompat  notifyManager;
+
+    private android.os.Handler clearHandler;
+    private Context mContext;
+
+    
+    public void init(MainActivity mainActivity) {
+        mContext = mainActivity.getApplicationContext();
+        clearHandler = new Handler(Looper.getMainLooper());
+
+        createNotificationChannels();
+        notifyManager = NotificationManagerCompat.from(mContext);
+        startStatusNotification();
+    }
+
+
+    private void createNotificationChannels() {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            int importance;
+            NotificationChannel channel;
+            NotificationManager notificationManager = mContext.getSystemService(NotificationManager.class);
+
+            //Status
+            importance = NotificationManager.IMPORTANCE_DEFAULT;
+
+            channel = new NotificationChannel(REMAINING_ID+"", REMAINING_CN, importance);
+            channel.setDescription(REMAINING_CD);
+            channel.setSound(null, null);
+            notificationManager.createNotificationChannel(channel);
+
+            //Alert
+            importance = NotificationManager.IMPORTANCE_HIGH;
+
+            channel = new NotificationChannel(ALERT_75_ID+"", ALERT_75_CN, importance);
+            channel.setDescription(ALERT_75_CD);
+            channel.setVibrationPattern(new long[]{0,500});
+            channel.enableVibration(true);
+            notificationManager.createNotificationChannel(channel);
+
+            channel = new NotificationChannel(ALERT_50_ID+"", ALERT_50_CN, importance);
+            channel.setDescription(ALERT_50_CD);
+            channel.setVibrationPattern(new long[]{0,500,500,500});
+            channel.enableVibration(true);
+            notificationManager.createNotificationChannel(channel);
+
+            channel = new NotificationChannel(ALERT_25_ID+"", ALERT_25_CN, importance);
+            channel.setDescription(ALERT_25_CD);
+            channel.setVibrationPattern(new long[]{0,500,500,500,500,500});
+            channel.enableVibration(true);
+            notificationManager.createNotificationChannel(channel);
+
+            channel = new NotificationChannel(ALERT_05_ID+"", ALERT_05_CN, importance);
+            channel.setDescription(ALERT_05_CD);
+            channel.setVibrationPattern(new long[]{0,500,500,500,500,500,500,500});
+            channel.enableVibration(true);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    private void startStatusNotification() {
+        notifyStatus = new NotificationCompat.Builder(mContext, REMAINING_ID+"")
+                        .setSmallIcon(R.mipmap.ic_launcher)
+                        .setContentTitle("Onewheel Status")
+                        .setColor(Color.parseColor("#fcb103"))
+                        .setContentText("Waiting for connection...")
+                        .setOngoing(true)
+                        .setAutoCancel(true);
+        notifyManager.notify(REMAINING_ID, notifyStatus.build());
+
+        notifyAlert75 = new NotificationCompat.Builder(mContext, ALERT_75_ID+"")
+                        .setGroup(ALERT_GR_KEY)
+                        .setSmallIcon(R.mipmap.ic_launcher)
+                        .setContentTitle("Onewheel Alerts")
+                        .setColor(Color.parseColor("#fcb103"))
+                        .setContentText(ALERT_75_CN)
+                        .setOngoing(false)
+                        .setAutoCancel(true);
+
+        notifyAlert50 = new NotificationCompat.Builder(mContext, ALERT_50_ID+"")
+                        .setGroup(ALERT_GR_KEY)
+                        .setSmallIcon(R.mipmap.ic_launcher)
+                        .setContentTitle("Onewheel Alerts")
+                        .setColor(Color.parseColor("#fcb103"))
+                        .setContentText(ALERT_50_CN)
+                        .setOngoing(false)
+                        .setAutoCancel(true);
+
+        notifyAlert25 = new NotificationCompat.Builder(mContext, ALERT_25_ID+"")
+                        .setGroup(ALERT_GR_KEY)
+                        .setSmallIcon(R.mipmap.ic_launcher)
+                        .setContentTitle("Onewheel Alerts")
+                        .setColor(Color.parseColor("#fcb103"))
+                        .setContentText(ALERT_25_CN)
+                        .setOngoing(false)
+                        .setAutoCancel(true);
+
+        notifyAlert05 = new NotificationCompat.Builder(mContext, ALERT_05_ID+"")
+                        .setGroup(ALERT_GR_KEY)
+                        .setSmallIcon(R.mipmap.ic_launcher)
+                        .setContentTitle("Onewheel Alerts")
+                        .setColor(Color.parseColor("#fcb103"))
+                        .setContentText(ALERT_05_CN)
+                        .setOngoing(false)
+                        .setAutoCancel(true);
+    }
+
+
+    public void stopStatusNotification() {
+	   notifyManager.cancelAll();
+    }
+
+    public void event(String title, String message) {
+        NotificationCompat.Builder mBuilder =
+                new NotificationCompat.Builder(mContext, "ponewheel")
+                        .setSmallIcon(R.mipmap.ic_launcher)
+                        .setContentTitle(title)
+                        .setColor(0x008000)
+                        .setContentText(message);
+
+        PendingIntent contentIntent = PendingIntent.getActivity(mContext, 0,
+                new Intent(mContext, MainActivity.class), PendingIntent.FLAG_UPDATE_CURRENT);
+        mBuilder.setContentIntent(contentIntent);
+
+        notifyManager.notify(message, 1, mBuilder.build());
+    }
+
+    public void status(int percent) {
+        notifyStatus.setContentText(percent+"%");
+        notifyManager.notify(REMAINING_ID, notifyStatus.build());
+    }
+
+    public void alert(int percent) {
+        final int alert_id;
+        NotificationCompat.Builder notify_alert = notifyStatus;
+
+        switch(percent) {
+            case 75:
+                alert_id = ALERT_75_ID;
+                notify_alert = notifyAlert75;
+                break;
+            case 50:
+                alert_id = ALERT_50_ID;
+                notify_alert = notifyAlert50;
+                break;
+            case 25:
+                alert_id = ALERT_25_ID;
+                notify_alert = notifyAlert25;
+                break;
+            case 5:
+                alert_id = ALERT_05_ID;
+                notify_alert = notifyAlert05;
+                break;
+            default:
+                alert_id = 0;
+                Timber.d("alert percentage:" + percent);
+        }
+
+        if (alert_id > 0) {
+            notifyManager.notify(alert_id, notify_alert.build());
+
+            clearHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    notifyManager.cancel(alert_id);
+                }
+            }, 10000);
+        }
+    }
+
+}

--- a/app/src/main/java/net/kwatts/powtools/util/Notify.java
+++ b/app/src/main/java/net/kwatts/powtools/util/Notify.java
@@ -53,6 +53,11 @@ public class Notify {
     private android.os.Handler clearHandler;
     private Context mContext;
 
+    private int lastPercent = -1;
+    private boolean alert75 = true;
+    private boolean alert50 = true;
+    private boolean alert25 = true;
+    private boolean alert05 = true;
     
     public void init(MainActivity mainActivity) {
         mContext = mainActivity.getApplicationContext();
@@ -175,6 +180,10 @@ public class Notify {
     public void waiting() {
         notifyStatus.setContentText("Waiting for connection...");
         notifyManager.notify(REMAINING_ID, notifyStatus.build());
+        alert75 = true;
+        alert50 = true;
+        alert25 = true;
+        alert05 = true;
     }
 
     public void status(int percent) {
@@ -183,39 +192,36 @@ public class Notify {
     }
 
     public void alert(int percent) {
-        final int alert_id;
-        NotificationCompat.Builder notify_alert = notifyStatus;
+        final int clear_id;
 
-        switch(percent) {
-            case 75:
-                alert_id = ALERT_75_ID;
-                notify_alert = notifyAlert75;
-                break;
-            case 50:
-                alert_id = ALERT_50_ID;
-                notify_alert = notifyAlert50;
-                break;
-            case 25:
-                alert_id = ALERT_25_ID;
-                notify_alert = notifyAlert25;
-                break;
-            case 5:
-                alert_id = ALERT_05_ID;
-                notify_alert = notifyAlert05;
-                break;
-            default:
-                alert_id = 0;
-                Timber.d("alert percentage:" + percent);
+        if (alert75 && lastPercent > 75 && percent <= 75) {
+            notifyManager.notify(ALERT_75_ID, notifyAlert75.build());
+            clear_id = ALERT_75_ID;
+            alert75 = false;
+        } else if (alert50 && lastPercent > 50 && percent <= 50) {
+            notifyManager.notify(ALERT_50_ID, notifyAlert50.build());
+            clear_id = ALERT_50_ID;
+            alert50 = false;
+        } else if (alert25 && lastPercent > 25 && percent <= 25) {
+            notifyManager.notify(ALERT_25_ID, notifyAlert25.build());
+            clear_id = ALERT_25_ID;
+            alert25 = false;
+        } else if (alert05 && lastPercent > 5 && percent <= 5) {
+            notifyManager.notify(ALERT_05_ID, notifyAlert05.build());
+            clear_id = ALERT_05_ID;
+            alert05 = false;
+        } else {
+            clear_id = -1;
         }
 
-        if (alert_id > 0) {
-            notifyManager.notify(alert_id, notify_alert.build());
+        lastPercent = percent;
 
+        if (clear_id > 0) {
             // These don't really need to stick around, cancel after 10s
             clearHandler.postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    notifyManager.cancel(alert_id);
+                    notifyManager.cancel(clear_id);
                 }
             }, 10000);
         }

--- a/app/src/main/java/net/kwatts/powtools/util/Notify.java
+++ b/app/src/main/java/net/kwatts/powtools/util/Notify.java
@@ -41,6 +41,7 @@ public class Notify {
     private static final String ALERT_05_CN  = "Battery 5% Remaining";
     private static final String ALERT_05_CD  = "Alarm when battery is 5%";
 
+    // Breaking these up allows for individual notify settings
     private NotificationCompat.Builder notifyStatus;
     private NotificationCompat.Builder notifyAlert75;
     private NotificationCompat.Builder notifyAlert50;
@@ -60,7 +61,7 @@ public class Notify {
         createNotificationChannels();
         notifyManager = NotificationManagerCompat.from(mContext);
         startStatusNotification();
-	   waiting();
+        waiting();
     }
 
 
@@ -153,7 +154,7 @@ public class Notify {
 
 
     public void stopStatusNotification() {
-	   notifyManager.cancelAll();
+       notifyManager.cancelAll();
     }
 
     public void event(String title, String message) {
@@ -210,6 +211,7 @@ public class Notify {
         if (alert_id > 0) {
             notifyManager.notify(alert_id, notify_alert.build());
 
+            // These don't really need to stick around, cancel after 10s
             clearHandler.postDelayed(new Runnable() {
                 @Override
                 public void run() {

--- a/app/src/main/java/net/kwatts/powtools/util/Notify.java
+++ b/app/src/main/java/net/kwatts/powtools/util/Notify.java
@@ -5,22 +5,15 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.graphics.Color;
 import android.location.Address;
 import android.net.Uri;
 import android.os.Build;
-import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.os.SystemClock;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
-import android.support.v4.app.ActivityCompat;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.app.AppCompatDelegate;
-import android.support.v4.content.ContextCompat;
 
 import net.kwatts.powtools.MainActivity;
 import net.kwatts.powtools.R;
@@ -28,13 +21,10 @@ import net.kwatts.powtools.R;
 import timber.log.Timber;
 
 public class Notify {
-    private static final String TAG_STATUS   = "powStatusNotificationTag";
     private static final int    REMAINING_ID = 101;
     private static final String REMAINING_CN = "Battery Status";
     private static final String REMAINING_CD = "Show battery status for Onewheel";
 
-    private static final String TAG_ALERT    = "powAlertNotificationTag";
-    private static final String ALERT_GR_KEY = "pow_alert_group";
     private static final int    ALERT_75_ID  = 201;
     private static final String ALERT_75_CN  = "Battery 75% Remaining";
     private static final String ALERT_75_CD  = "Alarm when battery is 75%";
@@ -70,6 +60,7 @@ public class Notify {
         createNotificationChannels();
         notifyManager = NotificationManagerCompat.from(mContext);
         startStatusNotification();
+	   waiting();
     }
 
 
@@ -126,10 +117,8 @@ public class Notify {
                         .setContentText("Waiting for connection...")
                         .setOngoing(true)
                         .setAutoCancel(true);
-        notifyManager.notify(REMAINING_ID, notifyStatus.build());
 
         notifyAlert75 = new NotificationCompat.Builder(mContext, ALERT_75_ID+"")
-                        .setGroup(ALERT_GR_KEY)
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("Onewheel Alerts")
                         .setColor(Color.parseColor("#fcb103"))
@@ -138,7 +127,6 @@ public class Notify {
                         .setAutoCancel(true);
 
         notifyAlert50 = new NotificationCompat.Builder(mContext, ALERT_50_ID+"")
-                        .setGroup(ALERT_GR_KEY)
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("Onewheel Alerts")
                         .setColor(Color.parseColor("#fcb103"))
@@ -147,7 +135,6 @@ public class Notify {
                         .setAutoCancel(true);
 
         notifyAlert25 = new NotificationCompat.Builder(mContext, ALERT_25_ID+"")
-                        .setGroup(ALERT_GR_KEY)
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("Onewheel Alerts")
                         .setColor(Color.parseColor("#fcb103"))
@@ -156,7 +143,6 @@ public class Notify {
                         .setAutoCancel(true);
 
         notifyAlert05 = new NotificationCompat.Builder(mContext, ALERT_05_ID+"")
-                        .setGroup(ALERT_GR_KEY)
                         .setSmallIcon(R.mipmap.ic_launcher)
                         .setContentTitle("Onewheel Alerts")
                         .setColor(Color.parseColor("#fcb103"))
@@ -183,6 +169,11 @@ public class Notify {
         mBuilder.setContentIntent(contentIntent);
 
         notifyManager.notify(message, 1, mBuilder.build());
+    }
+
+    public void waiting() {
+        notifyStatus.setContentText("Waiting for connection...");
+        notifyManager.notify(REMAINING_ID, notifyStatus.build());
     }
 
     public void status(int percent) {

--- a/app/src/main/java/net/kwatts/powtools/util/SharedPreferencesUtil.java
+++ b/app/src/main/java/net/kwatts/powtools/util/SharedPreferencesUtil.java
@@ -27,7 +27,6 @@ public class SharedPreferencesUtil implements net.kwatts.powtools.util.SharedPre
     public static final String DEVICE_RECONNECT = "deviceReconnect";
     public static final String OW_MAC_ADDRESS = "ow_mac_address";
     public static final String OW_MAC_NAME = "ow_mac_name";
-    public static final String STATUS_MODE = "status_mode";
     private static final String CHARGE_ALERT = "CHARGE_ALERT";
     public static final String SPEED_ALERT = "SPEED_ALERT";
     private static final String CHARGE_ALERT_ENABLED = "CHARGE_ALERT_ENABLED";
@@ -190,16 +189,6 @@ public class SharedPreferencesUtil implements net.kwatts.powtools.util.SharedPre
 
     public boolean getSpeedAlertEnabled() {
         return androidSharedPreferences.getBoolean(SPEED_ALERT_ENABLED, false);
-    }
-
-    public void setStatusMode(int status) {
-        SharedPreferences.Editor editor = androidSharedPreferences.edit();
-        editor.putInt(STATUS_MODE, status);
-        editor.commit();
-    }
-
-    public int getStatusMode() {
-        return this.androidSharedPreferences.getInt(STATUS_MODE, 0);
     }
 
 }


### PR DESCRIPTION
Fixes #105, updates #76 .

This moves statusMode out of sharedPreferences, cleans up the loopers/creates a periodic bluetooth query, and cleans up notifications. Remaining % is now a progress bar.  I have vibration working, and each notification is its own entity, so you can use Android notification settings to change the sound or other settings for a specific notification. For example, I opened the Android notification manager settings and set the 50% notification to use the Onewheel App's turnaround warning sound.

With this, I think a basic level of capability to guess battery remaining is ready for end-user testing.  My hope is that from here, we just need to tweak the parameters inside `Battery.java` and maybe add a sharedPreference or two to adjust for board-to-board differences.  We can't know that until we get feedback from multiple boards.

Thanks for reviewing this pull request, let me know if we need to make any changes.