### PR TITLE
increase priority on lock screen

### DIFF
--- a/app/src/main/java/net/kwatts/powtools/util/Notify.java
+++ b/app/src/main/java/net/kwatts/powtools/util/Notify.java
@@ -1,5 +1,6 @@
 package net.kwatts.powtools.util;
 
+import android.app.Notification;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -143,6 +144,7 @@ public class Notify {
                         .setContentTitle("Battery:")
                         .setColor(Color.parseColor("#fcb103"))
                         .setContentText("-%")
+                        .setPriority(Notification.PRIORITY_MAX)
                         .setContentIntent(contentIntent)
                         .setOngoing(true)
                         .setAutoCancel(false);


### PR DESCRIPTION
I couldn't see the battery meter on the lock screen from other notifications coming in, this increases its priority so it is more likely to be visible.