### PR TITLE
Battery temp issue56

### DIFF
--- a/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
+++ b/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
@@ -608,7 +608,7 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
         Timber.d("batteryTemp = %d, %d", batteryTemp1, batteryTemp2);
 
         setFormattedTempWithMetricPreference(dc, batteryTemp1, batteryTemp2);
-        updateBatteryChanges |= Battery.setBatteryTemp(batteryTemp1);
+        updateBatteryChanges |= Battery.setBatteryTemp((batteryTemp1+batteryTemp2) / 2);
     }
 
     public void processUnknownUuid(String incomingUuid, byte[] incomingValue) {

--- a/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
+++ b/app/src/main/java/net/kwatts/powtools/model/OWDevice.java
@@ -366,8 +366,9 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
         characteristics.get(MockOnewheelCharacteristicSpeed).ui_name.set(isMetric ? "(KMH)" : "(MPH)");
         characteristics.get(MockOnewheelCharacteristicOdometer).ui_name.set("TRIP ODOMETER " + (isMetric ? "(KM)" : "(MILES)"));
         characteristics.get(OnewheelCharacteristicLifetimeOdometer).ui_name.set("LIFETIME ODOMETER " + (isMetric ? "(KM)" : "(MILES)"));
-        characteristics.get(OnewheelCharacteristicTemperature).ui_name.set("CONTROLLER TEMP " + (isMetric ? "(C)" : "(F)"));
-        characteristics.get(MockOnewheelCharacteristicMotorTemp).ui_name.set("MOTOR TEMP " + (isMetric ? "(C)" : "(F)"));
+        characteristics.get(OnewheelCharacteristicTemperature).ui_name.set("CONTROLLER TEMP " + (isMetric ? "(°C)" : "(°F)"));
+        characteristics.get(MockOnewheelCharacteristicMotorTemp).ui_name.set("MOTOR TEMP " + (isMetric ? "(°C)" : "(°F)"));
+        characteristics.get(OnewheelCharacteristicBatteryTemp).ui_name.set("BATTERY TEMPS " + (isMetric ? "(°C)" : "(°F)"));
     }
 
 
@@ -579,7 +580,12 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
 
     public void setFormattedTempWithMetricPreference(DeviceCharacteristic deviceCharacteristic, int temp) {
         boolean isMetric = App.INSTANCE.getSharedPreferences().isMetric();
-        deviceCharacteristic.value.set(String.format(Locale.getDefault(), "%.2f", isMetric ? (double) temp : cel2far(temp)));
+        deviceCharacteristic.value.set(String.format(Locale.getDefault(), "%.0f", isMetric ? (double) temp : cel2far(temp)));
+    }
+
+    public void setFormattedTempWithMetricPreference(DeviceCharacteristic deviceCharacteristic, int temp1, int temp2) {
+        boolean isMetric = App.INSTANCE.getSharedPreferences().isMetric();
+        deviceCharacteristic.value.set(String.format(Locale.getDefault(), "%.0f, %.0f", isMetric ? (double) temp1 : cel2far(temp1), isMetric ? (double) temp2 : cel2far(temp2)));
     }
 
     public void setFormattedSpeedWithMetricPreference(DeviceCharacteristic deviceCharacteristic, double speedRpm) {
@@ -596,12 +602,13 @@ gatttool --device=D0:39:72:BE:0A:32 --char-write-req --value=7500 --handle=0x004
     }
 
     public void processBatteryTemp(BluetoothGattCharacteristic incomingCharacteristic, DeviceCharacteristic dc) {
-        int batteryTemp = incomingCharacteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT8, 0);
+        int batteryTemp1 = incomingCharacteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT8, 0);
+        int batteryTemp2 = incomingCharacteristic.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT8, 1);
 
-        Timber.d("batteryTemp = " + batteryTemp);
+        Timber.d("batteryTemp = %d, %d", batteryTemp1, batteryTemp2);
 
-        setFormattedTempWithMetricPreference(dc, batteryTemp);
-        updateBatteryChanges |= Battery.setBatteryTemp(batteryTemp);
+        setFormattedTempWithMetricPreference(dc, batteryTemp1, batteryTemp2);
+        updateBatteryChanges |= Battery.setBatteryTemp(batteryTemp1);
     }
 
     public void processUnknownUuid(String incomingUuid, byte[] incomingValue) {

--- a/app/src/main/java/net/kwatts/powtools/util/debugdrawer/DebugDrawerAddDummyRide.java
+++ b/app/src/main/java/net/kwatts/powtools/util/debugdrawer/DebugDrawerAddDummyRide.java
@@ -112,6 +112,12 @@ public class DebugDrawerAddDummyRide implements DebugModule, LifecycleObserver {
                 attribute.setValue("" + (Math.sin(i) * 20.0 + 90));
                 attributes.add(attribute);
 
+                attribute = new Attribute();
+                attribute.setMomentId(momentId);
+                attribute.setKey(OWDevice.KEY_BATTERY_TEMP);
+                attribute.setValue("" + (Math.sin(i) * 10.0 + 80));
+                attributes.add(attribute);
+
 
                 attribute = new Attribute();
                 attribute.setMomentId(momentId);

--- a/app/src/main/res/layout/main_grid_of_characteristics.xml
+++ b/app/src/main/res/layout/main_grid_of_characteristics.xml
@@ -49,6 +49,10 @@
         <TextView android:text='@{owdevice.getDeviceCharacteristicByKey(owdevice.KEY_TILT_ANGLE_ROLL).value}' style="@style/GridItemRight" />
         <TextView android:text="@{owdevice.getDeviceCharacteristicByKey(owdevice.KEY_CONTROLLER_TEMP).ui_name}" style="@style/GridItemLeft" />
         <TextView android:text='@{owdevice.getDeviceCharacteristicByKey(owdevice.KEY_CONTROLLER_TEMP).value}' style="@style/GridItemRight" />
+        <TextView android:text="@{owdevice.getDeviceCharacteristicByKey(owdevice.KEY_MOTOR_TEMP).ui_name}" style="@style/GridItemLeft" />
+        <TextView android:text='@{owdevice.getDeviceCharacteristicByKey(owdevice.KEY_MOTOR_TEMP).value}' style="@style/GridItemRight" />
+        <TextView android:text="@{owdevice.getDeviceCharacteristicByKey(owdevice.KEY_BATTERY_TEMP).ui_name}" style="@style/GridItemLeft" />
+        <TextView android:text='@{owdevice.getDeviceCharacteristicByKey(owdevice.KEY_BATTERY_TEMP).value}' style="@style/GridItemRight" />
 
         <!-- STATIC AND READ ONCE VALUES -->
         <TextView android:text="@string/onewheel_ble_name" style="@style/GridItemLeft" />


### PR DESCRIPTION
Resolves issue #56 .

Battery temperature is pulled every 60 seconds, and updated on MainActivity with both values provided by bluetooth.  I also added motor temperature to MainActivity.

All temperatures are now reported without decimal places.  The OW returns integers in °C, which is less precise than °F, there is no reason to provide riders with the illusion of two decimal places of accuracy.  Fewer numbers also makes it easier to read while riding, IMO.

After watching both numbers change while riding, I also decided to send the average of the two numbers to the Battery module.  If there are battery temperature censors, I am still not sure why there are only two temperature numbers returned and exactly what they represent.